### PR TITLE
More accurate acquisition of total and used media space

### DIFF
--- a/code/r_central/menu/menu_storage.cpp
+++ b/code/r_central/menu/menu_storage.cpp
@@ -102,11 +102,8 @@ void MenuStorage::onShow()
    
    media_scan_files();
 
-   #ifdef HW_PLATFORM_RASPBERRY
-   sprintf(szComm, "df -m %s | grep root", FOLDER_BINARIES);
-   #endif
-   #ifdef HW_PLATFORM_RADXA
-   sprintf(szComm, "df -m %s | grep mmc", FOLDER_BINARIES);
+   #if defined(HW_PLATFORM_RASPBERRY) || defined(HW_PLATFORM_RADXA)
+   sprintf(szComm, "df -m %s | tail -n 1", FOLDER_MEDIA);
    #endif
 
    if ( 1 == hw_execute_bash_command_raw(szComm, szBuff) )

--- a/code/r_central/ruby_central.cpp
+++ b/code/r_central/ruby_central.cpp
@@ -799,11 +799,8 @@ int ruby_start_recording()
 
    g_uVideoRecordStartTime = get_current_timestamp_ms();
 
-   #ifdef HW_PLATFORM_RASPBERRY
-   sprintf(szComm, "df -m %s | grep root", FOLDER_BINARIES);
-   #endif
-   #ifdef HW_PLATFORM_RADXA
-   sprintf(szComm, "df -m %s | grep mmc", FOLDER_BINARIES);
+   #if defined(HW_PLATFORM_RASPBERRY) || defined(HW_PLATFORM_RADXA)
+   sprintf(szComm, "df -m %s | tail -n 1", FOLDER_MEDIA);
    #endif
    if ( 1 == hw_execute_bash_command_raw(szComm, szBuff) )
    {


### PR DESCRIPTION
The media folder may be a symbolic link, a separate mount point or a bind mount, rather than being part of the root partition. Solve this by directly get the space usage of FOLDER_MEDIA.